### PR TITLE
기능추가🔧: #40 로그인 api 연동 및 자동 로그인 구현

### DIFF
--- a/EatDa.xcodeproj/project.pbxproj
+++ b/EatDa.xcodeproj/project.pbxproj
@@ -73,6 +73,10 @@
 		FD9C6F5027C11838005D88A6 /* FilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9C6F4F27C11838005D88A6 /* FilterView.swift */; };
 		FD9D4F7027B4EBA70005205E /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9D4F6F27B4EBA70005205E /* UIView.swift */; };
 		FD9D4F7227B503090005205E /* TitleSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9D4F7127B503090005205E /* TitleSectionView.swift */; };
+		FDB40681283E11A8003C70A8 /* Const.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB40680283E11A8003C70A8 /* Const.swift */; };
+		FDB40685283E14B1003C70A8 /* KeyChainKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB40684283E14B1003C70A8 /* KeyChainKey.swift */; };
+		FDB40687283E14D5003C70A8 /* TokenUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB40686283E14D5003C70A8 /* TokenUtils.swift */; };
+		FDB4068B283E3EB2003C70A8 /* SignIn.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB4068A283E3EB2003C70A8 /* SignIn.swift */; };
 		FDB7906D2805A704008621D1 /* RestaurantTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB7906C2805A704008621D1 /* RestaurantTableViewCell.swift */; };
 		FDB7906E2805A783008621D1 /* ReviewFeedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0CF62C27A12BDA00BDEA53 /* ReviewFeedViewController.swift */; };
 		FDD8DDCD27A423450072034C /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDD8DDCC27A423450072034C /* HomeViewController.swift */; };
@@ -165,6 +169,10 @@
 		FD9C6F4F27C11838005D88A6 /* FilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterView.swift; sourceTree = "<group>"; };
 		FD9D4F6F27B4EBA70005205E /* UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
 		FD9D4F7127B503090005205E /* TitleSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleSectionView.swift; sourceTree = "<group>"; };
+		FDB40680283E11A8003C70A8 /* Const.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Const.swift; sourceTree = "<group>"; };
+		FDB40684283E14B1003C70A8 /* KeyChainKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainKey.swift; sourceTree = "<group>"; };
+		FDB40686283E14D5003C70A8 /* TokenUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenUtils.swift; sourceTree = "<group>"; };
+		FDB4068A283E3EB2003C70A8 /* SignIn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignIn.swift; sourceTree = "<group>"; };
 		FDB7906C2805A704008621D1 /* RestaurantTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestaurantTableViewCell.swift; sourceTree = "<group>"; };
 		FDD8DDCC27A423450072034C /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		FDD8DDCF27A423740072034C /* FilterButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterButtonView.swift; sourceTree = "<group>"; };
@@ -281,12 +289,14 @@
 				F0CCC0EF2838DDB8007DCBD0 /* BottomStickyButton.swift */,
 				FD022E472833BB2200FC32E9 /* LikeButton.swift */,
 			);
-			path = Button;
+			name = Button;
+			path = ../Button;
 			sourceTree = "<group>";
 		};
 		F0CCC0F1283941F1007DCBD0 /* Util */ = {
 			isa = PBXGroup;
 			children = (
+				FDB4067F283E116E003C70A8 /* Constants */,
 				F0CCC0F328394226007DCBD0 /* APIResponse.swift */,
 			);
 			path = Util;
@@ -296,6 +306,7 @@
 			isa = PBXGroup;
 			children = (
 				F0CCC0F92839B830007DCBD0 /* School.swift */,
+				FDB4068A283E3EB2003C70A8 /* SignIn.swift */,
 			);
 			path = LoginModels;
 			sourceTree = "<group>";
@@ -305,7 +316,8 @@
 			children = (
 				F0CCC0FC2839E8DD007DCBD0 /* ProgressCheck.swift */,
 			);
-			path = ProgressCheck;
+			name = ProgressCheck;
+			path = ../ProgressCheck;
 			sourceTree = "<group>";
 		};
 		F0E4285927FC8EBD00C623E1 /* WritePost */ = {
@@ -338,6 +350,8 @@
 		FD022E462833BB0900FC32E9 /* UIComponent */ = {
 			isa = PBXGroup;
 			children = (
+				F0CCC0EC2838D304007DCBD0 /* Button */,
+				F0CCC0FB2839E880007DCBD0 /* ProgressCheck */,
 			);
 			path = UIComponent;
 			sourceTree = "<group>";
@@ -488,6 +502,23 @@
 			path = TitleView;
 			sourceTree = "<group>";
 		};
+		FDB4067F283E116E003C70A8 /* Constants */ = {
+			isa = PBXGroup;
+			children = (
+				FDB40680283E11A8003C70A8 /* Const.swift */,
+				FDB40686283E14D5003C70A8 /* TokenUtils.swift */,
+				FDB40684283E14B1003C70A8 /* KeyChainKey.swift */,
+			);
+			path = Constants;
+			sourceTree = "<group>";
+		};
+		FDB4068C283F461E003C70A8 /* UserService */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = UserService;
+			sourceTree = "<group>";
+		};
 		FDD8DDCB27A422C10072034C /* Home */ = {
 			isa = PBXGroup;
 			children = (
@@ -559,8 +590,6 @@
 			isa = PBXGroup;
 			children = (
 				FD022E462833BB0900FC32E9 /* UIComponent */,
-				F0CCC0FB2839E880007DCBD0 /* ProgressCheck */,
-				F0CCC0EC2838D304007DCBD0 /* Button */,
 				FD9C6F2E27BFD028005D88A6 /* Font */,
 			);
 			path = DesignSystem;
@@ -570,6 +599,7 @@
 			isa = PBXGroup;
 			children = (
 				F0CCC0F1283941F1007DCBD0 /* Util */,
+				FDB4068C283F461E003C70A8 /* UserService */,
 				FD022E432833ADF600FC32E9 /* Entities */,
 			);
 			path = Network;
@@ -722,6 +752,7 @@
 				F0CCC0F428394226007DCBD0 /* APIResponse.swift in Sources */,
 				F0224C3C28296FB90092683A /* VerifyEmailViewController.swift in Sources */,
 				F0128D38281E517F005BE0B9 /* SplashViewController.swift in Sources */,
+				FDB40685283E14B1003C70A8 /* KeyChainKey.swift in Sources */,
 				FDE37EAB27D37DCB00618163 /* HomeViewModel.swift in Sources */,
 				FDEA5E4727F834AA008EFD5E /* FilterViewModel.swift in Sources */,
 				FD6FBDB9283CF4A900BD7E20 /* RestaurantDetailViewModel.swift in Sources */,
@@ -748,6 +779,7 @@
 				FD0CF62B27A12BC400BDEA53 /* TalkViewController.swift in Sources */,
 				FD94861D27A959EF009BE666 /* AroundRestaurantCollectionViewCell.swift in Sources */,
 				FDEA5E3E27F04620008EFD5E /* RecommendDetailViewModel.swift in Sources */,
+				FDB40687283E14D5003C70A8 /* TokenUtils.swift in Sources */,
 				FD9C6F5027C11838005D88A6 /* FilterView.swift in Sources */,
 				F0224C44282970840092683A /* RegistCompleteViewController.swift in Sources */,
 				F0128D3A281E5531005BE0B9 /* LoginViewController.swift in Sources */,
@@ -757,6 +789,7 @@
 				F0224C422829704C0092683A /* EnterNicknameViewController.swift in Sources */,
 				FDF78A2527EB421B005D37C8 /* NoticeViewController.swift in Sources */,
 				F03D976827DDC4A10011FA3D /* BestBoardTVC.swift in Sources */,
+				FDB4068B283E3EB2003C70A8 /* SignIn.swift in Sources */,
 				FDD8DDD327A426C40072034C /* UIColor.swift in Sources */,
 				FD0DBC6027B8D9770001E526 /* MapSectionView.swift in Sources */,
 				F0CCC0E92838C9BA007DCBD0 /* SchoolSearchViewController.swift in Sources */,
@@ -788,6 +821,7 @@
 				FDF78A2927EB45AE005D37C8 /* NoticeTableViewCell.swift in Sources */,
 				FD63EA9927CCEDD600DFBD0B /* LikeViewController.swift in Sources */,
 				FDF78A2B27EB4C13005D37C8 /* NoticeHeaderView.swift in Sources */,
+				FDB40681283E11A8003C70A8 /* Const.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EatDa/Global/DesignSystem/UIComponent/ProgressCheck/ProgressCheck.swift
+++ b/EatDa/Global/DesignSystem/UIComponent/ProgressCheck/ProgressCheck.swift
@@ -1,0 +1,107 @@
+//
+//  ProgressCheck.swift
+//  EatDa
+//
+//  Created by 김희진 on 2022/05/22.
+//
+
+import Foundation
+import SnapKit
+import UIKit
+
+final class ProgressCheck: UIView {
+   
+    private lazy var index = 0
+    private lazy var stepList: [UIImageView] = []
+
+    init(index: Int, range: Int) {
+        super.init(frame: .zero)
+        self.index = index
+        for _ in 1...range {
+            let view = UIImageView()
+            view.backgroundColor = .white
+            view.image =  UIImage(named: "termUncheck")
+            self.stepList.append(view)
+            stepStackView.addArrangedSubview(view)
+        }
+        setupUI()
+    }
+
+    private lazy var stepStackView: UIStackView = {
+        let view = UIStackView()
+        view.spacing = 8
+        view.distribution = .fillEqually
+        view.axis = .horizontal
+        return view
+    }()
+    
+    private lazy var step1View: UIImageView = {
+        let view = UIImageView()
+        view.backgroundColor = .white
+        view.image =  UIImage(named: "termUncheck")
+        view.tag = 1
+        stepList.append(view)
+        return view
+    }()
+
+    private lazy var step2View: UIImageView = {
+        let view = UIImageView()
+        view.backgroundColor = .white
+        view.image =  UIImage(named: "termUncheck")
+        view.tag = 2
+        stepList.append(view)
+        return view
+    }()
+
+    private lazy var step3View: UIImageView = {
+        let view = UIImageView()
+        view.backgroundColor = .white
+        view.image =  UIImage(named: "termUncheck")
+        view.tag = 3
+        stepList.append(view)
+        return view
+    }()
+
+    private lazy var step4View: UIImageView = {
+        let view = UIImageView()
+        view.backgroundColor = .white
+        view.image =  UIImage(named: "termUncheck")
+        view.tag = 4
+        stepList.append(view)
+        return view
+    }()
+
+    private lazy var step5View: UIImageView = {
+        let view = UIImageView()
+        view.backgroundColor = .white
+        view.image =  UIImage(named: "termUncheck")
+        view.tag = 5
+        stepList.append(view)
+        return view
+    }()
+    
+    
+    func setupUI(){
+        addSubview(stepStackView)
+        stepStackView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+
+        if stepList.count > 0 {
+            for i in 0...index {
+                stepList[i].image = UIImage(named: "termCheck")
+                
+            }
+        }
+    }
+    
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+}

--- a/EatDa/Global/Network/Util/Constants/Const.swift
+++ b/EatDa/Global/Network/Util/Constants/Const.swift
@@ -1,0 +1,12 @@
+//
+//  Const.swift
+//  EatDa
+//
+//  Created by 김나희 on 5/25/22.
+//
+
+import Foundation
+
+struct Const {
+    static var headerToken: String = TokenUtils.read(key: Const.KeyChainKey.accessToken) ?? ""
+}

--- a/EatDa/Global/Network/Util/Constants/KeyChainKey.swift
+++ b/EatDa/Global/Network/Util/Constants/KeyChainKey.swift
@@ -1,0 +1,15 @@
+//
+//  KeyChainKey.swift
+//  EatDa
+//
+//  Created by 김나희 on 5/25/22.
+//
+
+import Foundation
+
+extension Const {
+    struct KeyChainKey {
+        static let accessToken = "accessToken"
+        static let refreshToken = "refreshToken"
+    }
+}

--- a/EatDa/Global/Network/Util/Constants/TokenUtils.swift
+++ b/EatDa/Global/Network/Util/Constants/TokenUtils.swift
@@ -1,0 +1,60 @@
+//
+//  TokenUtils.swift
+//  EatDa
+//
+//  Created by 김나희 on 5/25/22.
+//
+
+import Foundation
+import Security
+
+class TokenUtils {
+    // MARK: 키체인 생성
+    class func create(key: String, token: String) {
+        let query: NSDictionary = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key, // 저장할 account
+            kSecValueData: token.data(using: .utf8, allowLossyConversion: false) as Any // 저장할 토큰
+        ]
+        SecItemDelete(query) // 키체인에 중복이 생기면 저장 불가 -> 삭제 먼저 진행
+        
+        let status = SecItemAdd(query, nil)
+        assert(status == noErr, "토큰 저장에 실패하였습니다.")
+    }
+    
+    // MARK: 키체인 읽기
+    class func read(key: String) -> String? {
+        let query: NSDictionary = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key,
+            kSecReturnData: kCFBooleanTrue as Any, //CFData로 불러오기
+            kSecMatchLimit: kSecMatchLimitOne // 중복되는 경우, 하나의 값만 불러오기
+        ]
+        // CFData ?
+        // AnyObject로 받고 데이터로 타입변환해서 사용하면 됨
+        var dataTypeRef: AnyObject?
+        let status = SecItemCopyMatching(query, &dataTypeRef)
+        
+        if status == errSecSuccess {
+            if let retrievedData: Data = dataTypeRef as? Data {
+                let value = String(data: retrievedData, encoding: String.Encoding.utf8)
+                return value
+            } else { return nil }
+        } else {
+            print("\(status) 에러: 로딩에 실패하였습니다.")
+            return nil
+        }
+    }
+    
+    // MARK: 키체인 삭제
+    class func delete(key: String) {
+        let query: NSDictionary = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key
+        ]
+        
+        let status = SecItemDelete(query)
+        assert(status == noErr, "토큰 삭제에 실패하였습니다.")
+    }
+
+}

--- a/EatDa/SceneDelegate.swift
+++ b/EatDa/SceneDelegate.swift
@@ -17,14 +17,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(windowScene: windowScene)
         window?.backgroundColor = .systemBackground
-
+        let accessToken = TokenUtils.read(key: Const.KeyChainKey.accessToken)
         var rootVC: UIViewController
-        if UserDefaults.standard.bool(forKey: "loginComplete") {
-            rootVC = TabBarController()
-            
-            window?.rootViewController = rootVC
-            window?.makeKeyAndVisible()
-        }else {
+        
+        if accessToken != nil {
+            if UserDefaults.standard.bool(forKey: "loginComplete") {
+                rootVC = TabBarController()
+                window?.rootViewController = rootVC
+                window?.makeKeyAndVisible()
+            }
+        } else {
+        
             rootVC = LoginViewController()
             let navVC = UINavigationController(rootViewController: rootVC)
             window?.rootViewController = navVC
@@ -36,4 +39,3 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 //        window?.makeKeyAndVisible()
     }
 }
-

--- a/EatDa/Scenes/Login/LoginModels/SignIn.swift
+++ b/EatDa/Scenes/Login/LoginModels/SignIn.swift
@@ -1,0 +1,12 @@
+//
+//  SignIn.swift
+//  EatDa
+//
+//  Created by 김나희 on 5/25/22.
+//
+
+import Foundation
+
+struct SignIn: Decodable {
+    
+}

--- a/EatDa/Scenes/Login/LoginViewController.swift
+++ b/EatDa/Scenes/Login/LoginViewController.swift
@@ -8,6 +8,7 @@
 import Foundation
 import UIKit
 import RxSwift
+import Alamofire
 
 class GuideVO {
     var image: String?
@@ -74,10 +75,10 @@ class LoginViewController: UIViewController {
         button.titleLabel?.font = .myBoldSystemFont(ofSize: 14)
         button.rx.tap
             .bind {
-                let bottomSheetVC = BottomSheetViewController(contentViewController: SplashViewController())
-                bottomSheetVC.modalPresentationStyle = .overFullScreen
-                self.present(bottomSheetVC, animated: false, completion: nil)
-                
+//                let bottomSheetVC = BottomSheetViewController(contentViewController: SplashViewController())
+//                bottomSheetVC.modalPresentationStyle = .overFullScreen
+//                self.present(bottomSheetVC, animated: false, completion: nil)
+                self.signIn() // 임시
             }.disposed(by: disposeBag)
         return button
     }()
@@ -122,6 +123,20 @@ class LoginViewController: UIViewController {
         timer?.invalidate()
     }
     
+    func signIn() {
+        // 임의로 정보 넣어둠
+        let body: Parameters = [
+            "email": "cha2.hoon@gmail.com",
+            "password": 1
+        ]
+        
+        let apiCall = API<[SignIn]>(url: APIConstants.POST_SIGN_IN, method: .post, parameters: body)
+        apiCall.postSignInWithToken { result in
+            UserDefaults.standard.set(true, forKey: "loginComplete")
+            
+        }
+        
+    }
     
     func initUI(){
         [pageControl, loginButton, regiesterButton, noLoginLinkButton, collectionView].forEach { view.addSubview($0) }


### PR DESCRIPTION
## 요약 (개요) :
- [x] KeyChain에 AccessToken 및 RefreshToken 저장
- [x] 로그인 성공 시 UserDefaults에 명시
- [x] SceneDelegate에서 토큰 및 UserDefaults 확인 -> 첫 화면 결정
- [ ] 로그아웃 시 KeyChain read, delete 작업

## 주의사항 :
- 로그인 버튼에 임시 데이터로 로그인 api 연동해두었습니다!
- 현재 헤더에 AccessToken & RefreshToken 둘 다 넣어야함. (추후 서버 수정)