### PR TITLE
기능추가🔧 #40: request Method별 encoding 설정

### DIFF
--- a/EatDa.xcodeproj/project.pbxproj
+++ b/EatDa.xcodeproj/project.pbxproj
@@ -512,13 +512,6 @@
 			path = Constants;
 			sourceTree = "<group>";
 		};
-		FDB4068C283F461E003C70A8 /* UserService */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = UserService;
-			sourceTree = "<group>";
-		};
 		FDD8DDCB27A422C10072034C /* Home */ = {
 			isa = PBXGroup;
 			children = (
@@ -599,7 +592,6 @@
 			isa = PBXGroup;
 			children = (
 				F0CCC0F1283941F1007DCBD0 /* Util */,
-				FDB4068C283F461E003C70A8 /* UserService */,
 				FD022E432833ADF600FC32E9 /* Entities */,
 			);
 			path = Network;

--- a/EatDa/Global/Network/Util/APIResponse.swift
+++ b/EatDa/Global/Network/Util/APIResponse.swift
@@ -33,7 +33,9 @@ class API<T: Decodable> {
     
     let headers: HTTPHeaders = [
         "Content-Type":"application/json",
-        "Accept": "application/json"
+        "Accept": "application/json",
+        "Authorization": TokenUtils.read(key: Const.KeyChainKey.accessToken) ?? "",
+        "X-Refresh-Token": TokenUtils.read(key: Const.KeyChainKey.refreshToken) ?? ""
     ]
     
     init (url: String, method: HTTPMethod, parameters: Parameters) {
@@ -43,13 +45,31 @@ class API<T: Decodable> {
     }
     
     func fetch(completion: @escaping (APIResponse<T>) -> Void) {
+        var encodingType: ParameterEncoding {
+            switch self.method {
+            case .get, .delete:
+                return URLEncoding.default
+            case .post, .put:
+                return JSONEncoding.default
+            default:
+                return URLEncoding.default
+            }
+        }
+        
         AF.request(self.fetchURL,
                    method: self.method,
                    parameters: self.parameters,
-                   encoding: URLEncoding.default,
+                   encoding: encodingType,
                    headers: headers)
         .validate(statusCode: 200..<300)
         .responseJSON { response in
+            // 토큰 설정
+            guard let accessToken = response.response?.allHeaderFields["Authorization"] as? String else { return }
+            guard let refreshToken = response.response?.allHeaderFields["X-Refresh-Token"] as? String else { return }
+            // 토큰 키체인에 저장
+            TokenUtils.create(key: Const.KeyChainKey.accessToken, token: accessToken)
+            TokenUtils.create(key: Const.KeyChainKey.refreshToken, token: refreshToken)
+            
             switch response.result {
             case .success(let value):
                 
@@ -68,41 +88,5 @@ class API<T: Decodable> {
             
         }
     }
-    
-    
-    func postSignInWithToken(completion: @escaping (APIResponse<T>) -> Void) {
-        AF.request(self.fetchURL,
-                   method: self.method,
-                   parameters: self.parameters,
-                   encoding: JSONEncoding.default,
-                   headers: headers)
-        .validate(statusCode: 200..<300)
-        .responseJSON { response in
-            // 토큰 설정
-            guard let accessToken = response.response?.allHeaderFields["Authorization"] as? String else { return }
-            guard let refreshToken = response.response?.allHeaderFields["X-Refresh-Token"] as? String else { return }
-            // 토큰 키체인에 저장
-            
-            TokenUtils.create(key: Const.KeyChainKey.accessToken, token: accessToken)
-            TokenUtils.create(key: Const.KeyChainKey.refreshToken, token: refreshToken)
-                
-            switch response.result {
-            case .success(let value):
-                do {
-                    let jsonData = try JSONSerialization.data(withJSONObject: value, options: .prettyPrinted)
-                    let result = try JSONDecoder().decode(APIResponse<T>.self, from: jsonData)
-                    completion(result)
-                } catch (let err){
-                    print(err.localizedDescription)
-                }
-                
-            case .failure(let error):
-                print(error.localizedDescription)
-            }
-            
-        }
-    }
-    
-    
 
 }

--- a/EatDa/Scenes/Login/LoginViewController.swift
+++ b/EatDa/Scenes/Login/LoginViewController.swift
@@ -131,9 +131,11 @@ class LoginViewController: UIViewController {
         ]
         
         let apiCall = API<[SignIn]>(url: APIConstants.POST_SIGN_IN, method: .post, parameters: body)
-        apiCall.postSignInWithToken { result in
+        apiCall.fetch { result in
             UserDefaults.standard.set(true, forKey: "loginComplete")
-            
+            let mainVC = TabBarController()
+            mainVC.modalPresentationStyle = .fullScreen
+            self.present(mainVC, animated: false, completion: nil)
         }
         
     }


### PR DESCRIPTION
## 요약 (개요) :
- request Method별 api encoding 설정
- request 헤더에 토큰(access, refresh) 추가
- 로그인 성공 시 메인 화면 이동